### PR TITLE
Fix workflows to delete obsolete tags

### DIFF
--- a/.github/workflows/reset_test_unleash_e2e.yml
+++ b/.github/workflows/reset_test_unleash_e2e.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Delete all tags "v*.*.*"
         run: |
-          TAGS_TO_DELETE=$(git ls-remote --tags origin -l "v*.*.*" | awk '{print $2}')
+          TAGS_TO_DELETE=$(git ls-remote --refs --tags origin -l "v*.*.*" | awk '{print $2}')
           if [[ -n "${TAGS_TO_DELETE}" ]]; then
             git push -d origin ${TAGS_TO_DELETE}
           else

--- a/.github/workflows/test_unleash_e2e.yml
+++ b/.github/workflows/test_unleash_e2e.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Delete all tags "v*.*.*"
         run: |
-          TAGS_TO_DELETE=$(git ls-remote --tags origin -l "v*.*.*" | awk '{print $2}')
+          TAGS_TO_DELETE=$(git ls-remote --refs --tags origin -l "v*.*.*" | awk '{print $2}')
           if [[ -n "${TAGS_TO_DELETE}" ]]; then
             git push -d origin ${TAGS_TO_DELETE}
           else


### PR DESCRIPTION
- Issue:
  - git ls-remote --tags origin -l "v*.*.*" is listing de-referenced tags with ^{} appended
- Solution:
  - use git ls-remote --refs --tags origin -l "v*.*.*" instead
  - s. https://stackoverflow.com/a/35219362/15763374